### PR TITLE
Update build.gradle to remove 'compile'

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,15 +20,15 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.volley:volley:1.1.+'
-    compile('com.microsoft.aad:adal:1.14.+') {
+    implementation 'com.android.volley:volley:1.1.+'
+    implementation('com.microsoft.aad:adal:1.14.+') {
         exclude group: 'com.android.support'
     }
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    testImplementation 'junit:junit:4.12'
 }


### PR DESCRIPTION
Updated the file so we do not use the obsolete 'compile' but now use 'implementation'